### PR TITLE
Remove 'apple.com' from free email provider list

### DIFF
--- a/free_email_provider_domains.js
+++ b/free_email_provider_domains.js
@@ -1262,7 +1262,6 @@ app-inc-vol.ml
 appinventor.nl
 appixie.com
 appl3.tk
-apple.com
 apple.dnsabr.com
 apple.sib.ru
 appleaccount.app


### PR DESCRIPTION
@apple.com is not used for public emails, rather it's for Apple corp.

See https://support.apple.com/en-us/HT201771