### PR TITLE
Add SimpleLogin by ProtonMail

### DIFF
--- a/free_email_provider_domains.js
+++ b/free_email_provider_domains.js
@@ -13064,6 +13064,7 @@ simplebox.email
 simpleemail.in
 simpleemail.info
 simpleitsecurity.info
+simplelogin.com
 simplemail.in
 simplemail.top
 simplesport.ru


### PR DESCRIPTION
SimpleLogin is an Email Alias provider like Apple's Hide My Email or Firefox Relay

SimpleLogin website
https://simplelogin.io/

I know `simplelogin.com` is one of the domains they use for emails but not sure about simplelogin.io